### PR TITLE
Add support for styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,23 @@ SoPins are available in variety of formats:
 - JPEG
 - GIF
 - TIFF
+
+##Styles 
+
+SoPins has support for different styles for the pins, you can use either `flat` (default) , `plastic` and `flat-square` styles for your pins.
+
+Using different styles is very easy, you just need to enter a style parameter in your URL. 
+
+For example:
+
+```
+http://sopins.herokuapp.com/facebook/like/https://www.google.com/pin.png?style=flat-square
+```
+
+```
+http://sopins.herokuapp.com/linkedin/http://arstechnica.com/pin.png?style=plastic
+```
+
+```
+http://sopins.herokuapp.com/linkedin/https://github.com/pin.png?style=flat
+```

--- a/pins.py
+++ b/pins.py
@@ -35,7 +35,7 @@ class TwitterHandler(object):
             response = requests.get(url)
             response.raise_for_status()
         except requests.exceptions.HTTPError:
-            return self.write_shield('error', 'error', 'red')
+            return write_shield('error', 'error', 'red')
         else:
             data = json.loads(response.content)
             return write_shield(self.shield_subject, data['count'], 
@@ -51,7 +51,7 @@ class LinkedInHandler(object):
             response = requests.get(url)
             response.raise_for_status()
         except requests.exceptions.HTTPError:
-            return self.write_shield('error', 'error', 'red')
+            return write_shield('error', 'error', 'red')
         else:
             data = json.loads(response.content)
             return write_shield(self.shield_subject, data['count'], 
@@ -68,7 +68,7 @@ class FacebookHandler(object):
             response = requests.get(url)
             response.raise_for_status()
         except requests.exceptions.HTTPError:
-            return self.write_shield('error', 'error', 'red')
+            return write_shield('error', 'error', 'red')
         else:
             data = json.loads(response.content)[0]
             if fb_type == 'share':

--- a/pins.py
+++ b/pins.py
@@ -24,7 +24,7 @@ LinkedIn_URL = "https://www.linkedin.com/countserv/count/share?url=%s&format=jso
 SHIELD_URL = "http://img.shields.io/badge/%s-%s-%s.%s"
 
 
-class TwitterHandler():
+class TwitterHandler(object):
     '''Get the twitter json data for the url, and process.'''
     shield_subject = 'Tweet'
     shield_color = '55ACEE'
@@ -41,7 +41,7 @@ class TwitterHandler():
             return write_shield(self.shield_subject, data['count'], 
                 self.shield_color, format, endpoint=endpoint)
 
-class LinkedInHandler():
+class LinkedInHandler(object):
     shield_subject = 'LinkedIn Share'
     shield_color = '489DC9'
 
@@ -57,7 +57,7 @@ class LinkedInHandler():
             return write_shield(self.shield_subject, data['count'], 
                 self.shield_color, format, endpoint=endpoint)
 
-class FacebookHandler():
+class FacebookHandler(object):
     '''Get the facebook json data for the url, and process.'''
     shield_subject = 'Like'
     shield_color = '3b5998'
@@ -77,7 +77,6 @@ class FacebookHandler():
             else:
                 return write_shield(self.shield_subject, data['like_count'], 
                     self.shield_color, format, endpoint=endpoint)
-
 
 def write_shield(subject, count, color, format, endpoint=SHIELD_URL):
     '''Obtain and write the shield to the response.'''


### PR DESCRIPTION
This adds support for styles for the pins as given in the `shields.io` site. It's pretty easy to use, you just need to add a `style` parameter to the end of the url.
Example:
`http://sopins.herokuapp.com/twitter/https://www.google.com/pin.png?style=flat-square`
`http://sopins.herokuapp.com/twitter/https://www.google.com/pin.png?style=plastic`
